### PR TITLE
Fix "Unable to convert instance of imageview to type FFImageLoading.V…

### DIFF
--- a/Acquaint.Native/Acquaint.Native.Droid/Extensions/ViewExtensions.cs
+++ b/Acquaint.Native/Acquaint.Native.Droid/Extensions/ViewExtensions.cs
@@ -42,13 +42,13 @@ namespace Acquaint.Native.Droid
 			return imageView;
 		}
 
-		public static ImageViewAsync InflateAndBindLocalImageViewByResource(this View parentView, int imageViewResourceId, int resourceId)
+		public static ImageView InflateAndBindLocalImageViewByResource(this View parentView, int imageViewResourceId, int resourceId)
 		{
-			ImageViewAsync imageView = null;
+			ImageView imageView = null;
 
 			if (parentView != null)
 			{
-				imageView = parentView.FindViewById<ImageViewAsync>(imageViewResourceId);
+				imageView = parentView.FindViewById<ImageView>(imageViewResourceId);
 
 				imageView.SetImageResource(resourceId);
 			}


### PR DESCRIPTION
Hi,

We saw that you are using FFImageLoading in Acquaint.Native and some users reported this issue:
`Unable to convert instance of imageview to type FFImageLoading.Views.ImageViewAsync`.
Right now, it only happens with the beta channel but it is a valid issue: in the axml file you defined an ImageView but in code you declared an ImageViewAsync.

It is very easy to fix, since you don't use any FFImageLoading functionality for these images I reverted the code to use a regular ImageView.