### PR TITLE
VS related minor project updates

### DIFF
--- a/App/Acquaint.Native/Acquaint.Native.Droid/Acquaint.Native.Droid.csproj
+++ b/App/Acquaint.Native/Acquaint.Native.Droid/Acquaint.Native.Droid.csproj
@@ -16,7 +16,7 @@
     <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
     <AssemblyName>Acquaint.Native.Droid</AssemblyName>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
-    <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v7.0</TargetFrameworkVersion>
     <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
     <JavaMaximumHeapSize>1G</JavaMaximumHeapSize>
   </PropertyGroup>

--- a/App/Acquaint.XForms/Acquaint.XForms.UWP/Acquaint.XForms.UWP.nuget.props
+++ b/App/Acquaint.XForms/Acquaint.XForms.UWP/Acquaint.XForms.UWP.nuget.props
@@ -4,7 +4,7 @@
     <NuGetPackageRoot>$(UserProfile)\.nuget\packages\</NuGetPackageRoot>
   </PropertyGroup>
   <ImportGroup>
-    <Import Project="$(NuGetPackageRoot)\SQLitePCL\3.8.7.2\build\netcore451\SQLitePCL.props" Condition="Exists('$(NuGetPackageRoot)\SQLitePCL\3.8.7.2\build\netcore451\SQLitePCL.props')" />
-    <Import Project="$(NuGetPackageRoot)\Xamarin.Forms.Maps\2.3.2.127\build\win81\Xamarin.Forms.Maps.props" Condition="Exists('$(NuGetPackageRoot)\Xamarin.Forms.Maps\2.3.2.127\build\win81\Xamarin.Forms.Maps.props')" />
+    <Import Project="$(NuGetPackageRoot)sqlitepcl\3.8.7.2\build\netcore451\SQLitePCL.props" Condition="Exists('$(NuGetPackageRoot)sqlitepcl\3.8.7.2\build\netcore451\SQLitePCL.props')" />
+    <Import Project="$(NuGetPackageRoot)xamarin.forms.maps\2.3.2.127\build\win81\Xamarin.Forms.Maps.props" Condition="Exists('$(NuGetPackageRoot)xamarin.forms.maps\2.3.2.127\build\win81\Xamarin.Forms.Maps.props')" />
   </ImportGroup>
 </Project>

--- a/App/Acquaint.XForms/Acquaint.XForms.UWP/Acquaint.XForms.UWP.nuget.targets
+++ b/App/Acquaint.XForms/Acquaint.XForms.UWP/Acquaint.XForms.UWP.nuget.targets
@@ -4,10 +4,10 @@
     <NuGetPackageRoot>$(UserProfile)\.nuget\packages\</NuGetPackageRoot>
   </PropertyGroup>
   <ImportGroup>
-    <Import Project="$(NuGetPackageRoot)\Microsoft.Bcl.Build\1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('$(NuGetPackageRoot)\Microsoft.Bcl.Build\1.0.21\build\Microsoft.Bcl.Build.targets')" />
-    <Import Project="$(NuGetPackageRoot)\SQLitePCL\3.8.7.2\build\netcore451\SQLitePCL.targets" Condition="Exists('$(NuGetPackageRoot)\SQLitePCL\3.8.7.2\build\netcore451\SQLitePCL.targets')" />
-    <Import Project="$(NuGetPackageRoot)\SQLitePCLRaw.lib.e_sqlite3.v140\1.0.0\build\SQLitePCLRaw.lib.e_sqlite3.v140.targets" Condition="Exists('$(NuGetPackageRoot)\SQLitePCLRaw.lib.e_sqlite3.v140\1.0.0\build\SQLitePCLRaw.lib.e_sqlite3.v140.targets')" />
-    <Import Project="$(NuGetPackageRoot)\Xamarin.Forms\2.3.2.127\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('$(NuGetPackageRoot)\Xamarin.Forms\2.3.2.127\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />
-    <Import Project="$(NuGetPackageRoot)\Xamarin.Forms.Maps\2.3.2.127\build\win81\Xamarin.Forms.Maps.targets" Condition="Exists('$(NuGetPackageRoot)\Xamarin.Forms.Maps\2.3.2.127\build\win81\Xamarin.Forms.Maps.targets')" />
+    <Import Project="$(NuGetPackageRoot)microsoft.bcl.build\1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('$(NuGetPackageRoot)microsoft.bcl.build\1.0.21\build\Microsoft.Bcl.Build.targets')" />
+    <Import Project="$(NuGetPackageRoot)sqlitepcl\3.8.7.2\build\netcore451\SQLitePCL.targets" Condition="Exists('$(NuGetPackageRoot)sqlitepcl\3.8.7.2\build\netcore451\SQLitePCL.targets')" />
+    <Import Project="$(NuGetPackageRoot)sqlitepclraw.lib.e_sqlite3.v140\1.0.0\build\SQLitePCLRaw.lib.e_sqlite3.v140.targets" Condition="Exists('$(NuGetPackageRoot)sqlitepclraw.lib.e_sqlite3.v140\1.0.0\build\SQLitePCLRaw.lib.e_sqlite3.v140.targets')" />
+    <Import Project="$(NuGetPackageRoot)xamarin.forms\2.3.2.127\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('$(NuGetPackageRoot)xamarin.forms\2.3.2.127\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />
+    <Import Project="$(NuGetPackageRoot)xamarin.forms.maps\2.3.2.127\build\win81\Xamarin.Forms.Maps.targets" Condition="Exists('$(NuGetPackageRoot)xamarin.forms.maps\2.3.2.127\build\win81\Xamarin.Forms.Maps.targets')" />
   </ImportGroup>
 </Project>


### PR DESCRIPTION
* VS 2015 w/ Update 3 removes the slash after $(NuGetPackageRoot)
* Latest Xamarin.VS automatically updates TargeFrameworkVersion to 7.0
in Xamarin.Android projects